### PR TITLE
feat(dart): add support fort dart generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,5 +29,6 @@ npx lexigen -u <service-account-username> -s <service-account-secret> -p <projec
 ## Language support
 Currently supports the following generators:
 - Typescript.
+- Dart.
 
 > The generator assumes that the mixpanel tracking package is already installed and setup. It only imports the package at the top of the generated file.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ npx lexigen -u <service-account-username> -s <service-account-secret> -p <projec
   -p, --project   Mixpanel project id to pull the schema definitions from.
                                                              [string] [required]
   -t, --target    A target API to generate.
-                        [string] [choices: "typescript"] [default: "typescript"]
+                [string] [choices: "typescript", "dart"] [default: "typescript"]
   -f, --filter    Filters the events by a specific tag.                 [string]
 ```
 

--- a/src/generators/dart.ts
+++ b/src/generators/dart.ts
@@ -1,4 +1,4 @@
-import { pascalCase } from 'change-case'
+import { camelCase, pascalCase } from 'change-case'
 import { JSONSchema } from 'json-schema-to-typescript'
 
 import { EventSchema } from '../mixpanel'
@@ -12,11 +12,6 @@ const dartTypeMapping: { [key: string]: string } = {
   object: 'Map<String, dynamic>',
 }
 
-const lowerPascalCase = (str: string): string => {
-  const result = pascalCase(str)
-  return result.charAt(0).toLowerCase() + result.slice(1)
-}
-
 const generateDartMethod = (eventName: string, schema: JSONSchema): string => {
   const requiredFields = schema.required || []
   const properties = schema.properties || {}
@@ -25,13 +20,13 @@ const generateDartMethod = (eventName: string, schema: JSONSchema): string => {
     .map(([key, value]: [string, any]) => {
       const type = dartTypeMapping[value.type] || 'dynamic'
       const isRequired = requiredFields === true || requiredFields.includes(key)
-      const paramName = lowerPascalCase(key)
+      const paramName = camelCase(key)
       return `${isRequired ? 'required ' : ''}${type}${isRequired ? '' : '?'} ${paramName}`
     })
     .join(', ')
 
   const propertiesMap = Object.entries(properties)
-    .map(([key, _]) => `'${key}': ${lowerPascalCase(key)}`)
+    .map(([key, _]) => `'${key}': ${camelCase(key)}`)
     .join(',\n        ')
 
   if (!methodParams) {

--- a/src/generators/dart.ts
+++ b/src/generators/dart.ts
@@ -1,0 +1,66 @@
+import { pascalCase } from 'change-case'
+import { JSONSchema } from 'json-schema-to-typescript'
+
+import { EventSchema } from '../mixpanel'
+
+const dartTypeMapping: { [key: string]: string } = {
+  string: 'String',
+  number: 'double',
+  integer: 'int',
+  boolean: 'bool',
+  array: 'List',
+  object: 'Map<String, dynamic>',
+}
+
+const generateDartMethod = (eventName: string, schema: JSONSchema): string => {
+  const requiredFields = schema.required || []
+  const properties = schema.properties || {}
+
+  const methodParams = Object.entries(properties)
+    .map(([key, value]: [string, any]) => {
+      const type = dartTypeMapping[value.type] || 'dynamic'
+      const isRequired = requiredFields === true || requiredFields.includes(key)
+      const paramName = pascalCase(key)
+      return `${isRequired ? 'required ' : ''}${type}${isRequired ? '' : '?'} ${paramName}`
+    })
+    .join(', ')
+
+  const propertiesMap = Object.entries(properties)
+    .map(([key, _]) => `'${key}': ${pascalCase(key)}`)
+    .join(',\n        ')
+
+  if (!methodParams) {
+    return `  static void track${pascalCase(eventName)}Event() =>
+      _track('${eventName}');`
+  }
+
+  return `  static void track${pascalCase(eventName)}Event({
+    ${methodParams}
+  }) =>
+      _track('${eventName}', properties: <String, dynamic>{
+        ${propertiesMap},
+      });`
+}
+
+const formatDescription = (event: EventSchema): string => {
+  return event.schemaJson.description ? `/// ${event.schemaJson.description}\n` : ''
+}
+
+export const generate = async (events: EventSchema[]): Promise<string> => {
+  const eventMethods = events.map((event) => {
+    return `${formatDescription(event)}${generateDartMethod(event.name, event.schemaJson)}`
+  })
+
+  return `
+import 'package:mixpanel_flutter/mixpanel_flutter.dart';
+
+/// Abstract class to track analytics events
+abstract class AnalyticsEvents {
+  static void _track(String eventName, {Map<String, dynamic>? properties}) {
+    Mixpanel.instance.track(eventName, properties);
+  }
+
+${eventMethods.join('\n\n')}
+}
+`
+}

--- a/src/generators/dart.ts
+++ b/src/generators/dart.ts
@@ -12,6 +12,11 @@ const dartTypeMapping: { [key: string]: string } = {
   object: 'Map<String, dynamic>',
 }
 
+const lowerPascalCase = (str: string): string => {
+  const result = pascalCase(str)
+  return result.charAt(0).toLowerCase() + result.slice(1)
+}
+
 const generateDartMethod = (eventName: string, schema: JSONSchema): string => {
   const requiredFields = schema.required || []
   const properties = schema.properties || {}
@@ -20,13 +25,13 @@ const generateDartMethod = (eventName: string, schema: JSONSchema): string => {
     .map(([key, value]: [string, any]) => {
       const type = dartTypeMapping[value.type] || 'dynamic'
       const isRequired = requiredFields === true || requiredFields.includes(key)
-      const paramName = pascalCase(key)
+      const paramName = lowerPascalCase(key)
       return `${isRequired ? 'required ' : ''}${type}${isRequired ? '' : '?'} ${paramName}`
     })
     .join(', ')
 
   const propertiesMap = Object.entries(properties)
-    .map(([key, _]) => `'${key}': ${pascalCase(key)}`)
+    .map(([key, _]) => `'${key}': ${lowerPascalCase(key)}`)
     .join(',\n        ')
 
   if (!methodParams) {
@@ -54,10 +59,11 @@ export const generate = async (events: EventSchema[]): Promise<string> => {
   return `
 import 'package:mixpanel_flutter/mixpanel_flutter.dart';
 
-/// Abstract class to track analytics events
-abstract class AnalyticsEvents {
+class Lexicon {
+  static Mixpanel? mixpanel;
+
   static void _track(String eventName, {Map<String, dynamic>? properties}) {
-    Mixpanel.instance.track(eventName, properties);
+    mixpanel?.track(eventName, properties: properties);
   }
 
 ${eventMethods.join('\n\n')}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,15 +3,19 @@
 import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
 
+import { generate as generateDart } from './generators/dart'
 import { generate as generateTypescript } from './generators/typescripts'
 import { fetchEventsSchema } from './mixpanel'
 
+type GeneratorFunctionType = typeof generateTypescript
 enum GenerationOptions {
   typescript = 'typescript',
+  dart = 'dart',
 }
 
-const generators: Record<GenerationOptions, typeof generateTypescript> = {
+const generators: Record<GenerationOptions, GeneratorFunctionType> = {
   typescript: generateTypescript,
+  dart: generateDart,
 }
 
 const { username, secret, project, target, filter } = yargs(hideBin(process.argv))
@@ -36,7 +40,7 @@ const { username, secret, project, target, filter } = yargs(hideBin(process.argv
   .option('target', {
     alias: 't',
     type: 'string',
-    choices: [GenerationOptions.typescript],
+    choices: [GenerationOptions.typescript, GenerationOptions.dart],
     description: 'A target API to generate.',
     default: 'typescript',
   })


### PR DESCRIPTION
## What the PR Includes
- [x] Adds support for dart generators from mixpanel lexicon. Fixes https://linear.app/impargo/issue/DFS-1385/[lexigen]-dart-code-generation-support. 

Example code that is generated:
```dart
import 'package:mixpanel_flutter/mixpanel_flutter.dart';

class Lexicon {
  static Mixpanel? mixpanel;

  static void _track(String eventName, {Map<String, dynamic>? properties}) {
    mixpanel?.track(eventName, properties: properties);
  }

  /// Clicked on save & continue while creating an order during the send flow.
  static void trackSaveContinueEvent({String? featureName, String? workflow}) =>
      _track('Save & continue', properties: <String, dynamic>{
        'Feature Name': featureName,
        'Workflow': workflow,
      });

}
```

## Checklist
- [ ] Tests are added.
- [x] Manual testing instructions are added.
- [ ] Configs are added/adapted if applicable.
- [x] Issue is properly linked if applicable.

## Manual Testing Instructions
1. To test the PR run the command below to generate a dart file. 
2. Alternative you can [checkout this PR](https://github.com/impargo/impargo-driver-app/pull/1026) that implements an example in the IMPARGO DriverApp. 


Command to generate:
```
 npx ts-node src/index.ts  -u $USERNAME -s $KEY -p $PROJECT -t dart > lexicon.dart 
```