### PR TITLE
feat(mixpanel): allow also tracking server side events

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ npx lexigen -u <service-account-username> -s <service-account-secret> -p <projec
                                                              [string] [required]
   -t, --target    A target API to generate.
                 [string] [choices: "typescript", "dart"] [default: "typescript"]
+      --server-side, --ss  Generate server-side code. [boolean] [default: false]
   -f, --filter    Filters the events by a specific tag.                 [string]
 ```
 

--- a/src/generators/typescripts.ts
+++ b/src/generators/typescripts.ts
@@ -20,14 +20,31 @@ const formatDescription = (event: EventSchema): string => {
   return event.schemaJson.description ? `/**\n * ${event.schemaJson.description}\n */\n` : ''
 }
 
-export const generate = async (events: EventSchema[]): Promise<string> => {
+export const generate = async (events: EventSchema[], serverSide: boolean): Promise<string> => {
   const formattedEvents = await Promise.all(events.map(async event => {
     const interfaceName = `${pascalCase(event.name)}Properties`
     const functionName = `track${pascalCase(event.name)}Event`
     const params = await generateParamsForEvent(event, interfaceName)
     const shouldParamsBeOptional = !Object.keys(event.schemaJson.properties ?? {}).length
     // eslint-disable-next-line max-len
+    if (serverSide) {
+      return `${params}\n${formatDescription(event)}export const ${functionName} = (distinct_id: string, properties${shouldParamsBeOptional ? '?' : ''}: ${interfaceName}) => mixpanel?.track('${event.name}', { distinct_id, ...properties })`
+    }
+    // eslint-disable-next-line max-len
     return `${params}\n${formatDescription(event)}export const ${functionName} = (properties${shouldParamsBeOptional ? '?' : ''}: ${interfaceName}) => mixpanel.track('${event.name}', properties)`
   }))
-  return `/* eslint-disable */\nimport mixpanel from 'mixpanel-browser'\n\n${formattedEvents.join('\n\n')}`
+  if (serverSide) {
+    return `/* eslint-disable */
+import Mixpanel from 'mixpanel'
+
+let mixpanel: Mixpanel.Mixpanel | undefined
+export const initMixpanel = (token: string) => {
+  mixpanel = Mixpanel.init(token)
+}
+${formattedEvents.join('\n\n')}`
+  }
+  return `
+/* eslint-disable */
+import mixpanel from 'mixpanel-browser'
+${formattedEvents.join('\n\n')}`
 }

--- a/src/generators/typescripts.ts
+++ b/src/generators/typescripts.ts
@@ -28,7 +28,7 @@ export const generate = async (events: EventSchema[], serverSide: boolean): Prom
     const shouldParamsBeOptional = !Object.keys(event.schemaJson.properties ?? {}).length
     // eslint-disable-next-line max-len
     if (serverSide) {
-      return `${params}\n${formatDescription(event)}export const ${functionName} = (distinct_id: string, properties${shouldParamsBeOptional ? '?' : ''}: ${interfaceName}) => mixpanel?.track('${event.name}', { distinct_id, ...properties })`
+      return `${params}\n${formatDescription(event)}export const ${functionName} = async (userId: string, properties${shouldParamsBeOptional ? '?' : ''}: ${interfaceName}) => mixpanel?.track('${event.name}', { distinct_id: await sha256(userId), ...properties })`
     }
     // eslint-disable-next-line max-len
     return `${params}\n${formatDescription(event)}export const ${functionName} = (properties${shouldParamsBeOptional ? '?' : ''}: ${interfaceName}) => mixpanel.track('${event.name}', properties)`
@@ -41,10 +41,15 @@ let mixpanel: Mixpanel.Mixpanel | undefined
 export const initMixpanel = (token: string) => {
   mixpanel = Mixpanel.init(token)
 }
+const sha256 = async (str: string): Promise<string> => {
+  const buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(str))
+  return Array.prototype.map.call(new Uint8Array(buf), x => (('00' + x.toString(16)).slice(-2))).join('').slice(0, 16)
+}
 ${formattedEvents.join('\n\n')}`
   }
   return `
 /* eslint-disable */
 import mixpanel from 'mixpanel-browser'
+
 ${formattedEvents.join('\n\n')}`
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ const generators: Record<GenerationOptions, GeneratorFunctionType> = {
   dart: generateDart,
 }
 
-const { username, secret, project, target, filter } = yargs(hideBin(process.argv))
+const { username, secret, project, target, filter, serverSide } = yargs(hideBin(process.argv))
   .option('username', {
     alias: 'u',
     type: 'string',
@@ -44,6 +44,12 @@ const { username, secret, project, target, filter } = yargs(hideBin(process.argv
     description: 'A target API to generate.',
     default: 'typescript',
   })
+  .option('server-side', {
+    alias: 'ss',
+    type: 'boolean',
+    description: 'Generate server-side code.',
+    default: false,
+  })
   .option('filter', {
     alias: 'f',
     type: 'string',
@@ -52,5 +58,5 @@ const { username, secret, project, target, filter } = yargs(hideBin(process.argv
   .parseSync()
 
 fetchEventsSchema(username, secret, project, filter)
-  .then(generators[target as GenerationOptions])
+  .then((schema) => generators[target as GenerationOptions](schema, serverSide))
   .then(console.log)


### PR DESCRIPTION
## What the PR Includes
- [x] Allow generating mixpanel / typescript tracking code for both front-end (mixpanel-browser) and backend (mixpanel). 

Needed and can be tested with https://github.com/impargo/impargo-backend/pull/4060. 

